### PR TITLE
Restore bootnodes

### DIFF
--- a/realis.json
+++ b/realis.json
@@ -2,7 +2,9 @@
   "name": "Realis Network",
   "id": "realis",
   "chainType": "Live",
-  "bootNodes": [],
+  "bootNodes": ["/ip4/135.181.18.215/tcp/30333/p2p/12D3KooW9poizzemF6kb6iSbkoJynMhswa4oJe5W9v34eFuRcU47",
+                "/ip4/65.21.121.115/tcp/30333/p2p/12D3KooWBKFeHjMJj6PtoEzpmPscPKYaddS8xTTqecgDdmeywHM7",
+                "/ip4/135.181.19.52/tcp/30333/p2p/12D3KooWEhJou7RFWqPvNi5haBkwr68f3DhBSVoWcRDfC6xaLkjb"],
   "telemetryEndpoints": null,
   "protocolId": null,
   "properties": {


### PR DESCRIPTION
Looks like it was removed here:

```
commit df54888c4d88512b18f1d171d4991eb533a9e679
Author: Nikita <63471940+Daelon02@users.noreply.github.com>
Date:   Fri Nov 26 10:09:21 2021 +0200
...

diff --git a/realis.json b/realis.json
index ce3fa7e..30b7a43 100644
--- a/realis.json
+++ b/realis.json
@@ -2,9 +2,7 @@
   "name": "Realis Network",
   "id": "realis",
   "chainType": "Live",
-  "bootNodes": ["/ip4/135.181.18.215/tcp/30333/p2p/12D3KooW9poizzemF6kb6iSbkoJynMhswa4oJe5W9v34eFuRcU47",
-"/ip4/65.21.121.115/tcp/30333/p2p/12D3KooWBKFeHjMJj6PtoEzpmPscPKYaddS8xTTqecgDdmeywHM7",
-"/ip4/135.181.19.52/tcp/30333/p2p/12D3KooWEhJou7RFWqPvNi5haBkwr68f3DhBSVoWcRDfC6xaLkjb"],
+  "bootNodes": [],
```